### PR TITLE
min target set to jdk 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ def gitUrl = 'https://github.com/gde-vt/veritrans-java.git'
 def gitIssuesUrl = 'https://github.com/gde-vt/veritrans-java/issues'
 
 group = 'id.co.veritrans'
-version = '1.4.0'
+version = '1.4.1'
 
 sourceCompatibility = '1.7'
 targetCompatibility = '1.7'

--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,8 @@ def gitIssuesUrl = 'https://github.com/gde-vt/veritrans-java/issues'
 group = 'id.co.veritrans'
 version = '1.4.0'
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
+sourceCompatibility = '1.7'
+targetCompatibility = '1.7'
 
 // In this section you declare where to find the dependencies of your project
 repositories {
@@ -54,7 +54,6 @@ dependencies {
     compile 'javax.validation:validation-api:1.1.0.Final'
     compile 'org.hibernate:hibernate-validator:5.2.0.Beta1'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.8.4'
-    compile 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.8.4'
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.8.4'
 
     testCompile 'org.slf4j:log4j-over-slf4j:1.7.12'

--- a/src/main/java/id/co/veritrans/mdk/v1/helper/JsonUtil.java
+++ b/src/main/java/id/co/veritrans/mdk/v1/helper/JsonUtil.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import id.co.veritrans.mdk.v1.exception.JsonDeserializeException;
 import org.apache.http.HttpResponse;
@@ -59,7 +58,7 @@ public class JsonUtil {
 
         public VtJsonObjectMapper() {
             setDateFormat(new SimpleDateFormat(DEFAULT_DATE_FORMAT));
-            setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
+            setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
 
             configure(SerializationFeature.WRITE_NULL_MAP_VALUES, false);
 
@@ -70,7 +69,6 @@ public class JsonUtil {
 
             setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
 
-            registerModule(new Jdk8Module());
             registerModule(new JavaTimeModule());
         }
     }


### PR DESCRIPTION
min target set to jdk 7

## Why is this needed?

There's  a merchant who is still using JDK/JRE 7 and still want to retain usage of that version. 

All test: green.